### PR TITLE
WIP: Add Multi Device to One Connection Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ Where,
 - connectionProperties - stores the properties specific to their connection interface. These can be used to overwrite the default device connection properties. These properties implement the `MychIO.Connection.IConnectionProperties` interface and can be easily serialized/unserialized using the instantiated IConnection class (IDictionary<string, dynamic> <==> concrete IConnection object)
 - inputSubscriptions - Callbacks that are triggered by controller interaction mapped by device interaction zone enum
 
+<b>IMPORTANT</b> After devices have been added using the methods listed above you must call the IOManager ConnectDevices() method. This will connect all devices loaded. Note this was added to support multiple devices using the same connection.
+
+```C#
+public void ConnectDevices()
+```
+
 ## Connection/Device Properties
 
 The current implemented devices have the following connection objects:

--- a/Runtime/Connection/Connection.Base.cs
+++ b/Runtime/Connection/Connection.Base.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using MychIO.Device;
 using MychIO.Event;
@@ -12,20 +14,24 @@ namespace MychIO.Connection
     {
         public abstract bool IsConnected { get; }
         public abstract bool IsReading { get; }
-        
-        protected IDevice _device;
+
+        protected IList<IDevice> _devices;
         protected IConnectionProperties _connectionProperties;
         protected IOManager _manager;
+        protected DeviceClassification _classification;
+        protected string _types;
 
         public Connection(
-            IDevice device,
+            IList<IDevice> devices,
             IConnectionProperties connectionProperties,
             IOManager manager
          )
         {
-            _device = device;
+            _devices = devices;
             _connectionProperties = connectionProperties;
             _manager = manager;
+            _classification = devices.Count == 1 ? devices.First().Classification : DeviceClassification.MultipleDevice;
+            _types = string.Join(", ", devices.Select(d => d.GetType().ToString()));
         }
 
         public abstract void Connect();
@@ -40,21 +46,57 @@ namespace MychIO.Connection
         // to twice e.g. COM3 then you need to override this and check for that
         // all devices connected are passed to this method so you must check instance type!
         public abstract bool CanConnect(IConnection connectionProperties);
-        
+
         public abstract void Read();
 
         public abstract void StopReading();
         public abstract void Dispose();
 
+        protected void OnDeviceDisconnected()
+        {
+            foreach (var device in _devices)
+            {
+                device?.OnDisconnected();
+            }
+        }
+
+        protected async Task OnDeviceDisconnectedAsync()
+        {
+            foreach (var device in _devices)
+            {
+                await device.OnDisconnectedAsync();
+            }
+        }
+
+        protected void OnDeviceResetState()
+        {
+            foreach (var device in _devices)
+            {
+                device.ResetState();
+            }
+        }
+
+
+        protected void OnDeviceConnected()
+        {
+            foreach (var device in _devices)
+            {
+                device.OnConnected();
+            }
+        }
+
         protected void ValidateConnectionProperties<T>() where T : ConnectionProperties
         {
             if (_connectionProperties is not T)
             {
-                _manager.handleEvent(
-                    IOEventType.ConnectionError,
-                    _device.Classification,
-                    $"{_device.GetType().Name} Invalid properties object passed should be {typeof(T).Name} got {_connectionProperties.GetType().Name}"
-                );
+                foreach (var device in _devices)
+                {
+                    _manager.handleEvent(
+                        IOEventType.ConnectionError,
+                        device.Classification,
+                        $"{device.GetType().Name} Invalid properties object passed should be {typeof(T).Name} got {_connectionProperties.GetType().Name}"
+                    );
+                }
             }
         }
     }

--- a/Runtime/Connection/Connection.BuildProperties.cs
+++ b/Runtime/Connection/Connection.BuildProperties.cs
@@ -1,4 +1,5 @@
 using System;
+using MychIO.Device;
 
 namespace MychIO.Connection
 {
@@ -8,7 +9,6 @@ namespace MychIO.Connection
         {
             throw new NotImplementedException("Error GetConnectionType method not overwitten in base class");
         }
-
     }
 
 }

--- a/Runtime/Connection/ConnectionFactory.cs
+++ b/Runtime/Connection/ConnectionFactory.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using MychIO.Connection.HidDevice;
 using MychIO.Connection.SerialDevice;
-using MychIO.Connection.TouchPanelDevice;
 using MychIO.Device;
 
 namespace MychIO.Connection
@@ -16,7 +15,6 @@ namespace MychIO.Connection
         {
             { ConnectionType.HID, typeof(HidDeviceConnection) },
             { ConnectionType.SerialDevice, typeof(SerialDeviceConnection) },
-            { ConnectionType.TouchPanelDevice, typeof(TouchPanelDeviceConnection) }
             // Add other connections here...
         };
 

--- a/Runtime/Connection/ConnectionFactory.cs
+++ b/Runtime/Connection/ConnectionFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using MychIO.Connection.HidDevice;
@@ -19,47 +20,96 @@ namespace MychIO.Connection
             // Add other connections here...
         };
 
+        private static readonly ConcurrentDictionary<string, Func<List<IDevice>, IConnection>> connectionCreatorCallbacks = new();
+        private static readonly ConcurrentDictionary<string, IConnection> createdConnections = new();
+        private static readonly ConcurrentDictionary<string, List<IDevice>> deviceToConnectionMap = new();
         // Map of ConnectionProperties Unique String -> created connections
         // TODO: Add cleanup of this dictionary when no device holds the connection
         private static Dictionary<string, IConnection> spawnedConnections = new();
 
 
-        internal static IConnection GetConnection(IDevice device, IConnectionProperties connectionProperties, IOManager manager)
+        public static void PrepareConnection(IDevice device, IConnectionProperties props, IOManager manager)
         {
+            string id = props.UniqueConnectionIdentifier;
 
-
-            if (spawnedConnections.TryGetValue(connectionProperties.UniqueConnectionIdentifier, out var connection))
+            // If connection creation callback doesnt exist:
+            if (!deviceToConnectionMap.TryGetValue(id, out var deviceList))
             {
-                // add logic to add device
-                return connection;
+                deviceList = new List<IDevice>();
+                deviceToConnectionMap[id] = deviceList;
+
+                var connectionType = GetConnectionTypeFromDevice(device);
+
+                if (!_connectionTypeToConnection.TryGetValue(connectionType, out var connectionClassType))
+                    throw new Exception($"No connection type registered for {connectionType}");
+
+                connectionCreatorCallbacks[id] = (List<IDevice> devices) =>
+                {
+                    var constructor = connectionClassType.GetConstructors().First();
+                    return (IConnection)constructor.Invoke(new object[] { devices, props, manager });
+                };
             }
 
-
-            var deviceType = device.GetType();
-            var connectionTypeMethod = deviceType
-                .GetMethod(
-                    "GetConnectionType",
-                    System.Reflection.BindingFlags.Static |
-                    System.Reflection.BindingFlags.Public
-                 );
-            var connectionType = (ConnectionType)connectionTypeMethod.Invoke(null, null);
-
-            if (!_connectionTypeToConnection.TryGetValue(connectionType, out var connectionClassType))
+            // else device creation factory exists we can add the device directly to the list
+            if (!deviceList.Contains(device))
             {
-                throw new Exception("Could not find connection type for given device: " + device.GetType().Name);
+                deviceList.Add(device);
             }
-
-            var constructor = connectionClassType
-                .GetConstructors()
-                .First()
-            ;
-
-            if (constructor == null)
-            {
-                throw new Exception($"No suitable constructor found for device type {connectionClassType}");
-            }
-
-            return spawnedConnections[connectionProperties.UniqueConnectionIdentifier] = (IConnection)constructor.Invoke(new object[] { device, connectionProperties, manager });
         }
+
+        internal static IConnection GetConnection(IDevice device)
+        {
+            string id = device.ConnectionProperties.UniqueConnectionIdentifier;
+
+            // connection was already created using factory callback
+            if (createdConnections.TryGetValue(id, out var existingConnection))
+            {
+                return existingConnection;
+            }
+
+            if (!connectionCreatorCallbacks.TryGetValue(id, out var createConnection))
+            {
+                throw new Exception($"No connection prepared for device with ID: {id}");
+            }
+
+            // create connection
+            var connection = createConnection(deviceToConnectionMap[id]);
+            createdConnections[id] = connection;
+            return connection;
+        }
+
+        private static ConnectionType GetConnectionTypeFromDevice(IDevice device)
+        {
+            var method = device.GetType().GetMethod(
+                "GetConnectionType",
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public
+            );
+
+            return (ConnectionType)method.Invoke(null, null);
+        }
+
+        // Probably should use these somewhere:
+        internal static void ReleaseConnection(string id)
+        {
+            createdConnections.TryRemove(id, out _);
+            connectionCreatorCallbacks.TryRemove(id, out _);
+            deviceToConnectionMap.TryRemove(id, out _);
+        }
+
+        internal static void ClearAllConnections()
+        {
+            createdConnections.Clear();
+            connectionCreatorCallbacks.Clear();
+            deviceToConnectionMap.Clear();
+        }
+
+        private static void CleanupConnectionIfUnused(string connectionId)
+        {
+            if (deviceToConnectionMap.TryGetValue(connectionId, out var devices) && devices.Count == 0)
+            {
+                ReleaseConnection(connectionId);
+            }
+        }
+
     }
 }

--- a/Runtime/Connection/ConnectionFactory.cs
+++ b/Runtime/Connection/ConnectionFactory.cs
@@ -18,8 +18,22 @@ namespace MychIO.Connection
             { ConnectionType.TouchPanelDevice, typeof(TouchPanelDeviceConnection) }
             // Add other connections here...
         };
+
+        // Map of ConnectionProperties Unique String -> created connections
+        // TODO: Add cleanup of this dictionary when no device holds the connection
+        private static Dictionary<string, IConnection> spawnedConnections = new();
+
+
         internal static IConnection GetConnection(IDevice device, IConnectionProperties connectionProperties, IOManager manager)
         {
+
+
+            if (spawnedConnections.TryGetValue(connectionProperties.UniqueConnectionIdentifier, out var connection))
+            {
+                // add logic to add device
+                return connection;
+            }
+
 
             var deviceType = device.GetType();
             var connectionTypeMethod = deviceType
@@ -45,8 +59,7 @@ namespace MychIO.Connection
                 throw new Exception($"No suitable constructor found for device type {connectionClassType}");
             }
 
-            return (IConnection)constructor.Invoke(new object[] { device, connectionProperties, manager });
-
+            return spawnedConnections[connectionProperties.UniqueConnectionIdentifier] = (IConnection)constructor.Invoke(new object[] { device, connectionProperties, manager });
         }
     }
 }

--- a/Runtime/Connection/ConnectionProperties.cs
+++ b/Runtime/Connection/ConnectionProperties.cs
@@ -27,14 +27,18 @@ namespace MychIO.Connection
         }
         public abstract ConnectionType ConnectionType { get; }
 
+        // Used for linking ConnectionProperties to Connection Objects
+        public string UniqueConnectionIdentifier { get; }
+
         private Queue<string> _errors = new();
         private IDictionary<string, dynamic> _properties = new Dictionary<string, dynamic>();
 
         public int DebounceTimeMs = 0;
 
-        public ConnectionProperties(int debounceTimeMs = 0)
+        public ConnectionProperties(string uniqueConnectionIdentifier, int debounceTimeMs = 0)
         {
             DebounceTimeMs = debounceTimeMs;
+            UniqueConnectionIdentifier = uniqueConnectionIdentifier;
         }
 
         public IConnectionProperties UpdateProperties(IDictionary<string, dynamic> updateProperties)
@@ -93,6 +97,7 @@ namespace MychIO.Connection
                 }
             }
         }
+
         public TimeSpan GetDebounceThreshold()
         {
             return TimeSpan.FromMilliseconds(DebounceTimeMs);

--- a/Runtime/Connection/HID/HidDeviceConnection.cs
+++ b/Runtime/Connection/HID/HidDeviceConnection.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using MychIO.Device;
 using MychIO.Event;
 using MychIO.Helper;
+using UnityEditor.DeviceSimulation;
 
 namespace MychIO.Connection.HidDevice
 {
@@ -27,25 +30,29 @@ namespace MychIO.Connection.HidDevice
         // Holds C++ plugin object reference
         private IntPtr _pluginHandle;
 
-        public HidDeviceConnection(IDevice device, IConnectionProperties connectionProperties, IOManager manager) :
-         base(device, connectionProperties, manager)
+
+        public HidDeviceConnection(List<IDevice> devices, IConnectionProperties connectionProperties, IOManager manager) :
+         base(devices, connectionProperties, manager)
         {
 
             ValidateConnectionProperties<HidDeviceProperties>();
 
             if (1 != UnityHidApiPlugin.PluginLoaded())
             {
-                manager.handleEvent(
-                    IOEventType.ConnectionError,
-                        _device.Classification,
-                        "Error loading UnityHidApiPlugin plugin"
-                );
+                foreach (var device in devices)
+                {
+                    manager.handleEvent(
+                        IOEventType.ConnectionError,
+                            device.Classification,
+                            "Error loading UnityHidApiPlugin plugin"
+                    );
+                }
             }
 
             // UnityHidApiPlugin.DisposeByClassification((int)device.GetClassification());
             HidDeviceProperties properties = (HidDeviceProperties)connectionProperties;
             _pluginHandle = UnityHidApiPlugin.Initialize(
-                (int)device.Classification,
+                (int)_classification,
                 properties.VendorId,
                 properties.ProductId,
                 properties.BufferSize,
@@ -57,7 +64,7 @@ namespace MychIO.Connection.HidDevice
             {
                 manager.handleEvent(
                     IOEventType.ConnectionError,
-                    _device.Classification,
+                    _classification,
                     "Error Initializing HID Connection plugin, please recreate this device"
                 );
 
@@ -84,7 +91,7 @@ namespace MychIO.Connection.HidDevice
             }
             try
             {
-                _device?.OnDisconnected();
+                OnDeviceDisconnected();
             }
             catch { }
         }
@@ -120,13 +127,13 @@ namespace MychIO.Connection.HidDevice
             var eventReceivedCallback = new UnityHidApiPlugin.EventCallbackDelegate(
                 (string message) =>
                 {
-                    _manager.handleEvent(IOEventType.HidDeviceReadError, _device.Classification, _device.GetType().ToString() + " Error: " + message);
+                    _manager.handleEvent(IOEventType.HidDeviceReadError, _classification, _types + " Error: " + message);
                 }
             );
 
             if (!UnityHidApiPlugin.Connect(_pluginHandle, eventReceivedCallback))
             {
-                _manager.handleEvent(IOEventType.ConnectionError, _device.Classification, _device.GetType().ToString() + " Failed to Connect");
+                _manager.handleEvent(IOEventType.ConnectionError, _classification, _types + " Failed to Connect");
             }
 
             var dataReceivedCallback = GetRecieveDataFunction();
@@ -138,7 +145,7 @@ namespace MychIO.Connection.HidDevice
 
             if (IsReading)
             {
-                _manager.handleEvent(IOEventType.Attach, _device.Classification, _device.GetType().ToString() + " Device is running properly");
+                _manager.handleEvent(IOEventType.Attach, _classification, _types + " Device is running properly");
             }
 
             return Task.CompletedTask;
@@ -148,14 +155,41 @@ namespace MychIO.Connection.HidDevice
         private UnityHidApiPlugin.DataCallbackDelegate GetRecieveDataFunction()
         {
             var dt = _connectionProperties.GetDebounceThreshold();
+            if (1 == _devices.Count)
+            {
+                var device = _devices.First();
+                if (dt.TotalMilliseconds > 0)
+                {
+                    return new UnityHidApiPlugin.DataCallbackDelegate(device.ReadDataWithDebounce);
+                }
+                else
+                {
+                    return new UnityHidApiPlugin.DataCallbackDelegate(device.ReadData);
+                }
+            }
+
             if (dt.TotalMilliseconds > 0)
             {
-                return new UnityHidApiPlugin.DataCallbackDelegate(_device.ReadDataWithDebounce);
+                return new UnityHidApiPlugin.DataCallbackDelegate((IntPtr data) =>
+                {
+                    foreach (var device in _devices)
+                    {
+                        device.ReadDataWithDebounce(data);
+                    }
+                });
             }
             else
             {
-                return new UnityHidApiPlugin.DataCallbackDelegate(_device.ReadData);
+                return new UnityHidApiPlugin.DataCallbackDelegate((IntPtr data) =>
+                {
+                    foreach (var device in _devices)
+                    {
+                        device.ReadData(data);
+                    }
+                });
             }
+
+
         }
         public override void Disconnect()
         {
@@ -165,7 +199,7 @@ namespace MychIO.Connection.HidDevice
         {
             if (IsConnected)
             {
-                await _device.OnDisconnectedAsync();
+                await OnDeviceDisconnectedAsync();
             }
             UnityHidApiPlugin.Disconnect(_pluginHandle);
         }
@@ -180,7 +214,7 @@ namespace MychIO.Connection.HidDevice
 
             if (!UnityHidApiPlugin.IsReading(_pluginHandle))
             {
-                _manager.handleEvent(IOEventType.ConnectionError, _device.Classification, _device.GetType().ToString() + " Error: failed to start reading from device");
+                _manager.handleEvent(IOEventType.ConnectionError, _classification, _types + " Error: failed to start reading from device");
             }
         }
         public override void StopReading()

--- a/Runtime/Connection/HID/HidDeviceConnection.cs
+++ b/Runtime/Connection/HID/HidDeviceConnection.cs
@@ -136,7 +136,7 @@ namespace MychIO.Connection.HidDevice
             _eventCallbackHandle = GCHandle.Alloc(eventReceivedCallback);
             Read();
 
-            if(IsReading)
+            if (IsReading)
             {
                 _manager.handleEvent(IOEventType.Attach, _device.Classification, _device.GetType().ToString() + " Device is running properly");
             }
@@ -148,7 +148,7 @@ namespace MychIO.Connection.HidDevice
         private UnityHidApiPlugin.DataCallbackDelegate GetRecieveDataFunction()
         {
             var dt = _connectionProperties.GetDebounceThreshold();
-            if(dt.TotalMilliseconds > 0)
+            if (dt.TotalMilliseconds > 0)
             {
                 return new UnityHidApiPlugin.DataCallbackDelegate(_device.ReadDataWithDebounce);
             }

--- a/Runtime/Connection/HID/HidDeviceProperties.cs
+++ b/Runtime/Connection/HID/HidDeviceProperties.cs
@@ -1,3 +1,5 @@
+using MychIO.Helper;
+
 namespace MychIO.Connection.HidDevice
 {
     public class HidDeviceProperties : ConnectionProperties
@@ -19,7 +21,18 @@ namespace MychIO.Connection.HidDevice
             int bytesToRead = 64,
             int pollingRateMs = 0,
             int? debounceTimeMs = 0
-        ) : base(debounceTimeMs ?? 0)
+        ) : base(
+            GenerateUniqueIdentifier(
+                productId,
+                vendorId,
+                bufferSize,
+                leftBytesToTruncate,
+                bytesToRead,
+                pollingRateMs,
+                debounceTimeMs ?? 0
+            ),
+            debounceTimeMs ?? 0
+        )
         {
             ProductId = productId;
             VendorId = vendorId;
@@ -40,7 +53,18 @@ namespace MychIO.Connection.HidDevice
             int? bytesToRead = null,
             int? pollingRateMs = null,
             int? debounceTimeMs = 0
-        ) : base(debounceTimeMs ?? existing.DebounceTimeMs)
+        ) : base(
+            GenerateUniqueIdentifier(
+                productId ?? existing.ProductId,
+                vendorId ?? existing.VendorId,
+                bufferSize ?? existing.BufferSize,
+                leftBytesToTruncate ?? existing.LeftBytesToTruncate,
+                bytesToRead ?? existing.BytesToRead,
+                pollingRateMs ?? existing.PollingRateMs,
+                debounceTimeMs ?? 0
+            ),
+                debounceTimeMs ?? 0
+            )
         {
             ProductId = productId ?? existing.ProductId;
             VendorId = vendorId ?? existing.VendorId;
@@ -51,6 +75,26 @@ namespace MychIO.Connection.HidDevice
             PopulatePropertiesFromFields();
         }
 
+        private static string GenerateUniqueIdentifier(
+            int productId,
+            int vendorId,
+            int bufferSize,
+            int leftBytesToTruncate,
+            int bytesToRead,
+            int pollingRateMs,
+            int debounceTimeMs
+        )
+        {
+            return HelperFunctions.GenerateUniqueHashFromStrings(new string[] {
+                productId.ToString(),
+                vendorId.ToString(),
+                bufferSize.ToString(),
+                leftBytesToTruncate.ToString(),
+                bytesToRead.ToString(),
+                pollingRateMs.ToString(),
+                debounceTimeMs.ToString()
+            });
+        }
 
         public override ConnectionType ConnectionType
         {

--- a/Runtime/Connection/IConnection.cs
+++ b/Runtime/Connection/IConnection.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Threading.Tasks;
+using MychIO.Device;
 
 namespace MychIO.Connection
 {
-    public interface IConnection: IDisposable
+    public interface IConnection : IDisposable
     {
         bool IsConnected { get; }
         bool IsReading { get; }

--- a/Runtime/Connection/IConnectionProperties.cs
+++ b/Runtime/Connection/IConnectionProperties.cs
@@ -6,9 +6,12 @@ namespace MychIO.Connection
 {
     public interface IConnectionProperties : IIdentifier
     {
+        string UniqueConnectionIdentifier { get; }
         ConnectionType ConnectionType { get; }
         IDictionary<string, dynamic> Properties { get; }
         IConnectionProperties UpdateProperties(IDictionary<string, dynamic> updateProperties);
+
+
         // Used internally to store read errors
         IEnumerable<string> Errors { get; }
         TimeSpan GetDebounceThreshold();

--- a/Runtime/Connection/SerialDevice/AdxTouchPanelProperties.cs
+++ b/Runtime/Connection/SerialDevice/AdxTouchPanelProperties.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using MychIO.Helper;
 
 namespace MychIO.Connection.SerialDevice
 {
-    public class AdxTouchPanelProperties: SerialDeviceProperties
+    public class AdxTouchPanelProperties : SerialDeviceProperties
     {
         public bool SensitivityOverride;
         public int Sensitivity;
@@ -29,16 +30,16 @@ namespace MychIO.Connection.SerialDevice
             int sensitivity = 0,
             int? debounceTimeMs = 0
         ) : base(comPortNumber,
-            pollingRateMs, 
-            bufferByteLength, 
+            pollingRateMs,
+            bufferByteLength,
             readTimeoutMS,
-            writeTimeoutMS, 
-            portNumber, 
-            baudRate, 
-            stopBit, 
-            parityBit, 
-            dataBits, 
-            handshake, 
+            writeTimeoutMS,
+            portNumber,
+            baudRate,
+            stopBit,
+            parityBit,
+            dataBits,
+            handshake,
             dtr,
             rts,
             debounceTimeMs)

--- a/Runtime/Connection/SerialDevice/SerialDeviceConnection.cs
+++ b/Runtime/Connection/SerialDevice/SerialDeviceConnection.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Ports;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,10 +34,10 @@ namespace MychIO.Connection.SerialDevice
         private CancellationTokenSource _cts = new CancellationTokenSource();
 
         ReceiveDataHandler _onReceiveData;
-        public SerialDeviceConnection(IDevice device, IConnectionProperties connectionProperties, IOManager manager) :
-         base(device, connectionProperties, manager)
+        public SerialDeviceConnection(IList<IDevice> devices, IConnectionProperties connectionProperties, IOManager manager) :
+         base(devices, connectionProperties, manager)
         {
-            _onReceiveData = _device.ReadData;
+            _onReceiveData = GetReadDataReceiver();
         }
 
         public override void Connect()
@@ -78,7 +81,7 @@ namespace MychIO.Connection.SerialDevice
 
             if (!IsConnected)
             {
-                _manager.handleEvent(IOEventType.ConnectionError, _device.Classification, _device.GetType().ToString() + " Device lost COM port connection");
+                _manager.handleEvent(IOEventType.ConnectionError, _classification, _types + " Device lost COM port connection");
                 return Task.CompletedTask;
             }
 
@@ -86,7 +89,7 @@ namespace MychIO.Connection.SerialDevice
 
             if (IsReading)
             {
-                _manager.handleEvent(IOEventType.Attach, _device.Classification, _device.GetType().ToString() + " Device connected");
+                _manager.handleEvent(IOEventType.Attach, _classification, _types + " Device connected");
             }
 
             return Task.CompletedTask;
@@ -95,20 +98,21 @@ namespace MychIO.Connection.SerialDevice
         {
             DisconnectAsync().Wait();
         }
+
         public override async Task DisconnectAsync()
         {
-            _device.ResetState();
+            OnDeviceResetState();
             if (IsReading)
             {
                 await StopReadPollingAsync();
             }
             if (IsConnected)
             {
-                await _device.OnDisconnectedAsync();
+                await OnDeviceDisconnectedAsync();
                 _serialPort?.Close();
             }
             _serialPort = null;
-            _manager.handleEvent(IOEventType.Detach, _device.Classification, _device.GetType().ToString() + "device disconnected");
+            _manager.handleEvent(IOEventType.Detach, _classification, _types + "device disconnected");
         }
 
         public override void Write(ReadOnlySpan<byte> data)
@@ -157,7 +161,7 @@ namespace MychIO.Connection.SerialDevice
             if (!serialSession.IsOpen)
             {
                 serialSession.Open();
-                _device.OnConnected();
+                OnDeviceConnected();
             }
         }
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -183,15 +187,7 @@ namespace MychIO.Connection.SerialDevice
             {
                 return;
             }
-            var dt = _connectionProperties.GetDebounceThreshold();
-            if (dt.TotalMilliseconds > 0)
-            {
-                _onReceiveData = _device.ReadDataWithDebounce;
-            }
-            else
-            {
-                _onReceiveData = _device.ReadData;
-            }
+            _onReceiveData = GetReadDataReceiver();
             _readDataLoop = Task.Factory.StartNew(() =>
             {
                 ReadDataLoop(_onReceiveData);
@@ -199,7 +195,7 @@ namespace MychIO.Connection.SerialDevice
         }
         void ReadDataLoop(ReceiveDataHandler receiveDataHandler)
         {
-            _device.OnConnected();
+            OnDeviceConnected();
             try
             {
                 var token = _cts.Token;
@@ -218,7 +214,7 @@ namespace MychIO.Connection.SerialDevice
             catch (Exception e)
             {
                 // Throw event here potentially in the future for now just disconnect
-                _manager.handleEvent(IOEventType.ConnectionError, _device.Classification, _device.GetType().ToString() + "device connection failed due to following exception: " + e);
+                _manager.handleEvent(IOEventType.ConnectionError, _classification, _types + "device connection failed due to following exception: " + e);
                 Disconnect();
             }
         }
@@ -229,8 +225,38 @@ namespace MychIO.Connection.SerialDevice
         }
         public override void Dispose()
         {
-            _device?.OnDisconnected();
+            OnDeviceDisconnected();
             _cts.Cancel();
+        }
+
+        private ReceiveDataHandler GetReadDataReceiver()
+        {
+            var dt = _connectionProperties.GetDebounceThreshold();
+
+            if (dt.TotalMilliseconds > 0)
+            {
+                return (0 == _devices.Count) ?
+
+             (ReadOnlySpan<byte> data) =>
+                {
+                    foreach (var device in _devices)
+                    {
+                        device.ReadDataWithDebounce(data);
+                    }
+                }
+                : _devices.First().ReadDataWithDebounce;
+
+            }
+
+            return (0 == _devices.Count) ?
+             (ReadOnlySpan<byte> data) =>
+                {
+                    foreach (var device in _devices)
+                    {
+                        device.ReadData(data);
+                    }
+                }
+            : _devices.First().ReadData;
         }
     }
     static class SerialPortExtensions

--- a/Runtime/Connection/SerialDevice/SerialDeviceProperties.cs
+++ b/Runtime/Connection/SerialDevice/SerialDeviceProperties.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using MychIO.Helper;
+
 namespace MychIO.Connection.SerialDevice
 {
     public class SerialDeviceProperties : ConnectionProperties
@@ -35,7 +39,25 @@ namespace MychIO.Connection.SerialDevice
             bool dtr = false,
             bool rts = false,
             int? debounceTimeMs = 0
-        ) : base(debounceTimeMs ?? 0)
+        ) : base(
+            GenerateUniqueIdentifier(
+                comPortNumber,
+                pollingRateMs,
+                bufferByteLength,
+                readTimeoutMS,
+                writeTimeoutMS,
+                portNumber,
+                baudRate,
+                stopBit,
+                parityBit,
+                dataBits,
+                handshake,
+                dtr,
+                rts,
+                debounceTimeMs ?? 0
+            ),
+            debounceTimeMs ?? 0
+        )
         {
             ComPortNumber = comPortNumber;
             PollTimeoutMs = pollingRateMs;
@@ -70,7 +92,24 @@ namespace MychIO.Connection.SerialDevice
             bool? dtr = null,
             bool? rts = null,
             int? debounceTimeMs = 0
-        ) : base(debounceTimeMs ?? existing.DebounceTimeMs) 
+        ) : base(
+            GenerateUniqueIdentifier(
+             comPortNumber ?? existing.ComPortNumber,
+             pollingRateMs ?? existing.PollTimeoutMs,
+             bufferByteLength ?? existing.BufferByteLength,
+             readTimeoutMS ?? existing.ReadTimeoutMS,
+             writeTimeoutMS ?? existing.WriteTimeoutMS,
+             portNumber ?? existing.PortNumber,
+             baudRate ?? existing.BaudRate,
+             stopBit ?? existing.StopBit,
+             parityBit ?? existing.ParityBit,
+             dataBits ?? existing.DataBits,
+             handshake ?? existing.Handshake,
+             dtr ?? existing.Dtr,
+             rts ?? existing.Rts
+            ),
+            debounceTimeMs ?? 0
+        )
         {
             ComPortNumber = comPortNumber ?? existing.ComPortNumber;
             PollTimeoutMs = pollingRateMs ?? existing.PollTimeoutMs;
@@ -86,6 +125,41 @@ namespace MychIO.Connection.SerialDevice
             Dtr = dtr ?? existing.Dtr;
             Rts = rts ?? existing.Rts;
             PopulatePropertiesFromFields();
+        }
+
+        private static string GenerateUniqueIdentifier(
+            string comPortNumber,
+            int pollingRateMs,
+            int bufferByteLength,
+            int readTimeoutMS,
+            int writeTimeoutMS,
+            int portNumber,
+            BaudRate baudRate,
+            StopBits stopBit,
+            Parity parityBit,
+            DataBits dataBits,
+            Handshake handshake,
+            bool dtr,
+            bool rts,
+            int? debounceTimeMs = 0
+        )
+        {
+            return HelperFunctions.GenerateUniqueHashFromStrings(new string[] {
+                comPortNumber.ToString(),
+                pollingRateMs.ToString(),
+                bufferByteLength.ToString(),
+                readTimeoutMS.ToString(),
+                writeTimeoutMS.ToString(),
+                portNumber.ToString(),
+                baudRate.ToString(),
+                stopBit.ToString(),
+                parityBit.ToString(),
+                dataBits.ToString(),
+                handshake.ToString(),
+                dtr.ToString(),
+                rts.ToString(),
+                debounceTimeMs.HasValue ? debounceTimeMs.Value.ToString() : "0"
+            });
         }
 
         public override ConnectionType ConnectionType

--- a/Runtime/Connection/TouchPanel/TouchPanelDeviceConnection.cs
+++ b/Runtime/Connection/TouchPanel/TouchPanelDeviceConnection.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using MychIO.Device;
@@ -25,8 +28,8 @@ namespace MychIO.Connection.TouchPanelDevice
         // Holds C++ plugin object reference
         private IntPtr _pluginHandle;
 
-        public TouchPanelDeviceConnection(IDevice device, IConnectionProperties connectionProperties, IOManager manager) :
-         base(device, connectionProperties, manager)
+        public TouchPanelDeviceConnection(List<IDevice> devices, IConnectionProperties connectionProperties, IOManager manager) :
+         base(devices, connectionProperties, manager)
         {
 
             ValidateConnectionProperties<TouchPanelDeviceProperties>();
@@ -35,7 +38,7 @@ namespace MychIO.Connection.TouchPanelDevice
             {
                 manager.handleEvent(
                     IOEventType.ConnectionError,
-                        _device.Classification,
+                        _classification,
                         "Error loading UnityTouchPanelApiPlugin plugin"
                 );
             }
@@ -43,15 +46,15 @@ namespace MychIO.Connection.TouchPanelDevice
             // UnityTouchPanelApiPlugin.DisposeByClassification((int)device.GetClassification());
             TouchPanelDeviceProperties properties = (TouchPanelDeviceProperties)connectionProperties;
             _pluginHandle = UnityTouchPanelApiPlugin.Initialize(
-                (int)device.Classification,
+                (int)_classification,
                 properties.PollingRateMs,
-                (string message) => { manager.handleEvent(IOEventType.ConnectionError, device.Classification, message); }
+                (string message) => { manager.handleEvent(IOEventType.ConnectionError, _classification, message); }
             );
             if (_pluginHandle == IntPtr.Zero)
             {
                 manager.handleEvent(
                     IOEventType.ConnectionError,
-                    _device.Classification,
+                    _classification,
                     "Error Initializing Touch Panel Connection plugin, please recreate this device"
                 );
                 // This will destroy the initialized settings, TouchPanelDeviceConnection failed to initialize
@@ -77,7 +80,7 @@ namespace MychIO.Connection.TouchPanelDevice
             }
             try
             {
-                _device?.OnDisconnected();
+                OnDeviceDisconnected();
             }
             catch { }
         }
@@ -98,17 +101,17 @@ namespace MychIO.Connection.TouchPanelDevice
 
             // IsConnected() will always return true here since successful initilization
             // counts as connection so do not check
-            
+
             var eventReceivedCallback = new UnityTouchPanelApiPlugin.EventCallbackDelegate(
                 (string message) =>
                 {
-                    _manager.handleEvent(IOEventType.TouchPanelDeviceReadError, _device.Classification, _device.GetType().ToString() + " Error: " + message);
+                    _manager.handleEvent(IOEventType.TouchPanelDeviceReadError, _classification, _types + " Error: " + message);
                 }
             );
 
             if (!UnityTouchPanelApiPlugin.Connect(_pluginHandle, eventReceivedCallback))
             {
-                _manager.handleEvent(IOEventType.ConnectionError, _device.Classification, _device.GetType().ToString() + " Failed to Connect");
+                _manager.handleEvent(IOEventType.ConnectionError, _classification, _types + " Failed to Connect");
             }
 
             var dataReceivedCallback = GetRecieveDataFunction();
@@ -118,7 +121,7 @@ namespace MychIO.Connection.TouchPanelDevice
             _eventCallbackHandle = GCHandle.Alloc(eventReceivedCallback);
             Read();
 
-            _manager.handleEvent(IOEventType.Attach, _device.Classification, _device.GetType().ToString() + " Device is running properly");
+            _manager.handleEvent(IOEventType.Attach, _classification, _types + " Device is running properly");
 
             return Task.CompletedTask;
 
@@ -126,14 +129,40 @@ namespace MychIO.Connection.TouchPanelDevice
 
         private UnityTouchPanelApiPlugin.DataCallbackDelegate GetRecieveDataFunction()
         {
+
             var dt = _connectionProperties.GetDebounceThreshold();
-            if(dt.TotalMilliseconds > 0)
+            if (1 == _devices.Count)
             {
-                return new UnityTouchPanelApiPlugin.DataCallbackDelegate(_device.ReadDataWithDebounce);
+                var device = _devices.First();
+                if (dt.TotalMilliseconds > 0)
+                {
+                    return new UnityTouchPanelApiPlugin.DataCallbackDelegate(device.ReadDataWithDebounce);
+                }
+                else
+                {
+                    return new UnityTouchPanelApiPlugin.DataCallbackDelegate(device.ReadData);
+                }
+            }
+
+            if (dt.TotalMilliseconds > 0)
+            {
+                return new UnityTouchPanelApiPlugin.DataCallbackDelegate((IntPtr data) =>
+                {
+                    foreach (var device in _devices)
+                    {
+                        device.ReadDataWithDebounce(data);
+                    }
+                });
             }
             else
             {
-                return new UnityTouchPanelApiPlugin.DataCallbackDelegate(_device.ReadData);
+                return new UnityTouchPanelApiPlugin.DataCallbackDelegate((IntPtr data) =>
+                {
+                    foreach (var device in _devices)
+                    {
+                        device.ReadData(data);
+                    }
+                });
             }
         }
         public override void Disconnect()
@@ -144,7 +173,7 @@ namespace MychIO.Connection.TouchPanelDevice
         {
             if (IsConnected)
             {
-                await _device.OnDisconnectedAsync();
+                await OnDeviceDisconnectedAsync();
             }
             UnityTouchPanelApiPlugin.Disconnect(_pluginHandle);
         }
@@ -159,7 +188,7 @@ namespace MychIO.Connection.TouchPanelDevice
 
             if (!UnityTouchPanelApiPlugin.IsReading(_pluginHandle))
             {
-                _manager.handleEvent(IOEventType.ConnectionError, _device.Classification, _device.GetType().ToString() + " Error: failed to start reading from device");
+                _manager.handleEvent(IOEventType.ConnectionError, _classification, _types + " Error: failed to start reading from device");
             }
         }
         public override void StopReading()
@@ -183,5 +212,7 @@ namespace MychIO.Connection.TouchPanelDevice
         {
             return ThrowHelper.NotSupported<Task>();
         }
+
+
     }
 }

--- a/Runtime/Connection/TouchPanel/TouchPanelDeviceProperties.cs
+++ b/Runtime/Connection/TouchPanel/TouchPanelDeviceProperties.cs
@@ -8,7 +8,7 @@ namespace MychIO.Connection.TouchPanelDevice
         public TouchPanelDeviceProperties(
             int pollingRateMs = 2,
             int? debounceTimeMs = 0
-        ) : base(debounceTimeMs ?? 0)
+        ) : base("NOT IMPLEMENTED", debounceTimeMs ?? 0)
         {
             PollingRateMs = pollingRateMs;
             PopulatePropertiesFromFields();
@@ -19,7 +19,7 @@ namespace MychIO.Connection.TouchPanelDevice
             TouchPanelDeviceProperties existing,
             int? pollingRateMs = null,
             int? debounceTimeMs = 0
-        ) : base(debounceTimeMs ?? existing.DebounceTimeMs)
+        ) : base("NOT IMPLEMENTED", debounceTimeMs ?? existing.DebounceTimeMs)
         {
             PollingRateMs = pollingRateMs ?? existing.PollingRateMs;
             PopulatePropertiesFromFields();

--- a/Runtime/Device/Device.Base.cs
+++ b/Runtime/Device/Device.Base.cs
@@ -57,7 +57,8 @@ namespace MychIO.Device
         protected readonly IOManager _manager;
         protected readonly IConnectionProperties _connectionProperties;
         protected IDictionary<TZone, Action<TZone, TState>> _inputSubscriptions;
-        protected IConnection _connection;
+        protected IConnection? _connection;
+
         protected DeviceClassification _classification;
 
         protected Device(
@@ -96,9 +97,10 @@ namespace MychIO.Device
                 _lastInputTriggerTimes[zone] = TimeSpan.Zero;
             }
 
-            // Connect
-            _connection = ConnectionFactory.GetConnection(this, _connectionProperties, manager);
-            Id = _connectionProperties.Id;
+            // Connection is only prepared to be created here
+            // Connection Object is only created AFTER ConnectAsync is called!
+            ConnectionFactory.PrepareConnection(this, _connectionProperties, manager);
+            Id = _connectionProperties.Id; // device identifier should probably be actually unique i.e. UUID
             _manager = manager;
         }
 
@@ -120,8 +122,11 @@ namespace MychIO.Device
             _timeProvider.Restart();
             return task.Result;
         }
+
+        // Initializes device!
         public async Task<IDevice> ConnectAsync()
         {
+            _connection = ConnectionFactory.GetConnection(this);
             await _connection.ConnectAsync();
             return (IDevice)this;
         }

--- a/Runtime/Device/DeviceClassification.cs
+++ b/Runtime/Device/DeviceClassification.cs
@@ -5,6 +5,7 @@ namespace MychIO.Device
         TouchPanel,
         ButtonRing,
         LedDevice,
+        MultipleDevice,
         // Used exclusively for events not specific to a device
         Undefined,
     }

--- a/Runtime/Device/DeviceFactory.cs
+++ b/Runtime/Device/DeviceFactory.cs
@@ -21,7 +21,7 @@ namespace MychIO.Device
             // Add other devices here...
         };
 
-        public static async Task<IDevice> GetDeviceAsync(
+        public static async Task<Func<Task<IDevice>>> GetDeviceAsync(
             string deviceName,
             IDictionary<string, dynamic> connectionProperties = null,
             IDictionary<Enum, Action<Enum, Enum>> inputSubscriptions = null,
@@ -51,7 +51,7 @@ namespace MychIO.Device
                 manager.handleEvent(IOEventType.ConnectionError, message: $"Duplicate connection for {device.GetType().Name} already exists cannot connect");
             }
 
-            return await device.ConnectAsync();
+            return async () => await device.ConnectAsync();
         }
 
         public static DeviceClassification GetClassificationFromDeviceName(string deviceName)

--- a/Runtime/Helper/HelperFunctions.cs
+++ b/Runtime/Helper/HelperFunctions.cs
@@ -1,12 +1,36 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
 namespace MychIO.Helper
 {
-    // Mainly functions for debugging
     public class HelperFunctions
     {
+
+
+        public static string GenerateUniqueHashFromStrings(Array strings)
+        {
+            if (strings == null) throw new ArgumentNullException(nameof(strings));
+
+            var stringList = new List<string>();
+            foreach (var s in strings)
+            {
+                if (s is string str)
+                    stringList.Add(str);
+            }
+            var uniqueSorted = new SortedSet<string>(stringList);
+
+            var concatenated = string.Join("|", uniqueSorted);
+
+            using (var md5 = System.Security.Cryptography.MD5.Create())
+            {
+                var inputBytes = System.Text.Encoding.UTF8.GetBytes(concatenated);
+                var hashBytes = md5.ComputeHash(inputBytes);
+                return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
+            }
+        }
+
 
         public static string ConvertByteArrayToBitString(byte[] byteArray)
         {

--- a/Runtime/IOManager.cs
+++ b/Runtime/IOManager.cs
@@ -6,12 +6,13 @@ using System.Linq;
 using MychIO.Event;
 using System.Collections.Concurrent;
 using MychIO.Connection;
+using UnityEngine.UIElements;
 
 namespace MychIO
 {
     using DeviceClassificationToInputAction = Dictionary<DeviceClassification, IDictionary<Enum, Action<Enum, Enum>>>;
 #nullable enable
-    public class IOManager: IDisposable
+    public class IOManager : IDisposable
     {
 
         public const string STANDARD_INPUT = "standard-input";
@@ -28,10 +29,26 @@ namespace MychIO
         // Event System
         protected IDictionary<IOEventType, ControllerEventDelegate> _eventTypeToCallback = new Dictionary<IOEventType, ControllerEventDelegate>();
 
+        private readonly List<Task> _deviceAdditionTasks = new List<Task>();
+        protected IList<Func<Task>> _connectionQueue = new List<Func<Task>>();
+
         // Device Error Handler
         IDeviceErrorHandler? _deviceErrorHandler = null;
 
         public IOManager() { }
+
+        public void ConnectDevices()
+        {
+            Task.Run(async () =>
+            {
+                // ensure all devices are enqueued and ready
+                await Task.WhenAll(_deviceAdditionTasks);
+                foreach (Func<Task> callback in _connectionQueue)
+                {
+                    await callback();
+                }
+            });
+        }
 
         public void AddDeviceByName(
             string deviceName,
@@ -57,26 +74,34 @@ namespace MychIO
                 inputSubscriptions = setDeviceClassification;
             }
 
-            Task.Run(async () =>
+            var deviceAdditionTask = Task.Run(async () =>
             {
                 if (_deviceClassificationToDevice.TryGetValue(deviceClassification, out var oldDevice))
                 {
                     await oldDevice.DisconnectAsync();
                 }
 
-                var device = await DeviceFactory.GetDeviceAsync(
+                var deviceConnectionCallback = await DeviceFactory.GetDeviceAsync(
                     deviceName,
                     connectionProperties,
                     inputSubscriptions,
                     _deviceClassificationToDevice.Values.ToArray(),
                     this
                 );
-                _deviceClassificationToDevice.Add(device.Classification, device);
 
-                // Save for reloading
-                _tagToDeviceClassificationToDeviceInputAction[STANDARD_INPUT] =
-                new DeviceClassificationToInputAction { { deviceClassification, inputSubscriptions } };
+                _connectionQueue.Add(
+                async () =>
+                {
+                    var device = await deviceConnectionCallback();
+                    _deviceClassificationToDevice.Add(device.Classification, device);
+
+                    // Save for reloading
+                    _tagToDeviceClassificationToDeviceInputAction[STANDARD_INPUT] =
+                    new DeviceClassificationToInputAction { { deviceClassification, inputSubscriptions } };
+                });
             });
+
+            _deviceAdditionTasks.Add(deviceAdditionTask);
         }
 
         public void AddTouchPanel(
@@ -153,7 +178,7 @@ namespace MychIO
             return newDict;
         }
 
-        public async Task WriteToDeviceAsync<T>(DeviceClassification deviceClassification, params T[] command) where T:Enum
+        public async Task WriteToDeviceAsync<T>(DeviceClassification deviceClassification, params T[] command) where T : Enum
         {
             if (_deviceClassificationToDevice.TryGetValue(deviceClassification, out var device) && device.IsConnected)
             {
@@ -415,7 +440,7 @@ namespace MychIO
         }
         public void Dispose()
         {
-            foreach(var (k,v) in _deviceClassificationToDevice)
+            foreach (var (k, v) in _deviceClassificationToDevice)
             {
                 v.Disconnect();
             }


### PR DESCRIPTION
- Refactor ConnectionFactory so that an List<IDevice> will be passed to Device constructors (allowing for creation of multi delegates)
- Add unique Id to ConnecitonProperties based on properties set

- Add  ConnectDevices() to IOManager (required to be called after all devices have been attached to the manager)


TODO:

- Documentation
- Update Devices to accept an List<IDevice> and adjust logic to support multiple or singe callbacks
- Add special device type ALL or something